### PR TITLE
fix: static files and add production error logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ coverage.xml
 #Documentation
 .github
 TODO.md
+
+#STATIC FILES
+gamevault_backend/staticfiles/


### PR DESCRIPTION
- Revert to CompressedStaticFilesStorage (more stable than Manifest version)
- Conditionally set STATICFILES_DIRS (empty in production after collectstatic)
- Add comprehensive logging for debugging 500 errors in production
- Configure WhiteNoise to only use finders in DEBUG mode
- This should resolve both static file 404s and 500 errors